### PR TITLE
remove tests from array after expansion

### DIFF
--- a/qpm/scscripts/test_runner.scd
+++ b/qpm/scscripts/test_runner.scd
@@ -76,18 +76,22 @@
 		"Expanding %\n".postf(toExpand);
 		toExpand.do {
 			| wildcardTest |
-			var allTests, newTest, class;
+			var allTests, newTest, class, suite;
 
-			class = wildcardTest["suite"].asSymbol.asClass;
+			suite = wildcardTest["suite"];
+			class = suite.asSymbol.asClass;
 
 			if (class.respondsTo(\findTestMethods).not && class.notNil) {
 				class = ("Test" ++ class.name.asString).asSymbol.asClass;
 			};
 
 			if (class.isNil) {
-				wildcardTest["error"] = "Class % not found".format(class);
-				wildcardTest["completed"] = true;
-				~writeResult.(test_record, file);
+				newTest = Dictionary.newFrom((
+					"suite": suite,
+					"error": "Class % not found".format(suite),
+					"completed": true,
+				));
+				tests.add(newTest);
 			} {
 				class.tryPerform(\findTestMethods).do {
 					| test |

--- a/qpm/scscripts/test_runner.scd
+++ b/qpm/scscripts/test_runner.scd
@@ -100,10 +100,10 @@
 
 					tests.add(newTest);
 				};
-				tests.remove(wildcardTest);
-				~writeResult.(test_record, file);
 			}
 		};
+		tests.removeAll(toExpand);
+		~writeResult.(test_record, file);
 
 		// Ensure excluded tests are not run
 		toExclude = tests.select({


### PR DESCRIPTION
This PR addresses an issue with `qpm/scscripts/test_runner.scd` that comes up when trying to run large numbers of UnitTests. 

An error happens at random where the `tests` array, normally full of Dictionaries, contains some garbage data at one of its indexes (ex: a string`"skip": "test_asString_zero"`). 

I haven't been able to reproduce the error with this fix applied. I assume the fix is correct, but I can't be 100% sure. In any case, this change is innocuous. 